### PR TITLE
Fix configuration dependency resolution

### DIFF
--- a/controlplanes/ctp-dev/providers/aws/provider.yaml
+++ b/controlplanes/ctp-dev/providers/aws/provider.yaml
@@ -7,7 +7,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -18,7 +21,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -29,7 +35,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -40,7 +49,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -51,4 +63,7 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false

--- a/controlplanes/ctp-dev/providers/helm/provider.yaml
+++ b/controlplanes/ctp-dev/providers/helm/provider.yaml
@@ -7,4 +7,7 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false

--- a/controlplanes/ctp-prod/providers/aws/provider.yaml
+++ b/controlplanes/ctp-prod/providers/aws/provider.yaml
@@ -7,7 +7,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -18,7 +21,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -29,7 +35,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -40,7 +49,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -51,4 +63,7 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false

--- a/controlplanes/ctp-prod/providers/helm/provider.yaml
+++ b/controlplanes/ctp-prod/providers/helm/provider.yaml
@@ -7,4 +7,7 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false

--- a/controlplanes/ctp-staging/providers/aws/provider.yaml
+++ b/controlplanes/ctp-staging/providers/aws/provider.yaml
@@ -7,7 +7,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -18,7 +21,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -29,7 +35,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -40,7 +49,10 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
@@ -51,4 +63,7 @@ spec:
   packagePullPolicy: IfNotPresent
   revisionActivationPolicy: Automatic
   revisionHistoryLimit: 1
-  skipDependencyResolution: true
+  # We keep skipDependencyResolution disabled to work around a bug that
+  # prevents configuration dependencies from resolving.
+  # See https://github.com/crossplane/crossplane/issues/4588.
+  skipDependencyResolution: false


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

This sets `spec.skipDependencyResolution=false` on providers in order to work around https://github.com/crossplane/crossplane/issues/4588. This ensures that configurations are able to become healthy.

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

I deployed the cpt-dev manifests to a kind cluster with crossplane installed and observed that both providers and configurations become healthy.
